### PR TITLE
Updated method prependDescriptionTextWithMeetingCosts

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -74,7 +74,9 @@ function buttonClickEvent() {
 }
 
 function prependDescriptionTextWithMeetingCosts(descriptionInputElement, numberOfParticipants, costPerHour, durationInHours) {
-	descriptionInputElement.innerHTML = `[Meeting cost: $${numberOfParticipants * costPerHour * durationInHours}] - ${descriptionInputElement.innerHTML}`;
+	var unroundedMeetingCost = numberOfParticipants * costPerHour * durationInHours;
+	var roundedMeetingCost = Math.ceil(unroundedMeetingCost/100)*100
+	descriptionInputElement.innerHTML = `[Meeting cost: $${roundedMeetingCost}] - ${descriptionInputElement.innerHTML}`;
 }
 
 function removePlaceholderDescriptionText() {
@@ -121,4 +123,3 @@ function parseDomStartDate() {
 	const startDate = Date.parse(startTimeText);
 	return startDate;
 }
-

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -74,8 +74,8 @@ function buttonClickEvent() {
 }
 
 function prependDescriptionTextWithMeetingCosts(descriptionInputElement, numberOfParticipants, costPerHour, durationInHours) {
-	var unroundedMeetingCost = numberOfParticipants * costPerHour * durationInHours;
-	var roundedMeetingCost = Math.ceil(unroundedMeetingCost/100)*100
+	const unroundedMeetingCost = numberOfParticipants * costPerHour * durationInHours;
+	const roundedMeetingCost = Math.ceil(unroundedMeetingCost/100)*100
 	descriptionInputElement.innerHTML = `[Meeting cost: $${roundedMeetingCost}] - ${descriptionInputElement.innerHTML}`;
 }
 


### PR DESCRIPTION
In order to ensure a user-readable meeting cost is reliably generated, I've updated `prependDescriptionTextWithMeetingCosts` to make the following behaviours:

- Create `var unroundedMeetingCost` to store raw meeting cost value.
- Create `var roundedMeetingCost`to store meeting cost value to nearest and highest $100 value.
- Subsequent `roundedMeetingCost` is injected into `descriptionInputElement .innerHTML` 